### PR TITLE
Fix preceding-sexp depreaction warning in Emacs 25

### DIFF
--- a/erefactor.el
+++ b/erefactor.el
@@ -913,11 +913,17 @@ as a local variable.
       (funcall enabler (nth 0 x) (nth 1 x) (nth 2 x))
       (funcall 'ad-activate (nth 0 x)))))
 
+;; Emacs 25 renamed `preceding-sexp' to `elisp--preceding-sexp' and
+;; added a deprecation warning to using the old name. However some
+;; supported versions of Emacs don't have this alias.
+(unless (fboundp 'elisp--preceding-sexp)
+  (defalias 'elisp--preceding-sexp 'preceding-sexp))
+
 (defadvice eval-last-sexp
   (after erefactor-check-eval-last-sexp (edebug-it) activate)
   (when (erefactor-interactive-p)
-    ;; call `preceding-sexp' same as `eval-last-sexp'
-    (erefactor-check--form (preceding-sexp))))
+    ;; call `elisp--preceding-sexp' same as `eval-last-sexp'
+    (erefactor-check--form (elisp--preceding-sexp))))
 
 (defadvice eval-defun
   (after erefactor-check-eval-defun (edebug-it) activate)


### PR DESCRIPTION
As of [this commit](https://github.com/emacs-mirror/emacs/commit/e6cfa098ae23e34c5415642e2f848a92982924ef), `preceding-sexp` is deprecated in Emacs in favor of a new name "`elisp--preceding-sexp`".

This means that every time you start Emacs with erefactor configuration, you get this nifty message:

```
‘preceding-sexp’ is an obsolete function (as of 25.1); use ‘elisp--preceding-sexp’ instead.
```

This pull request updates all calls to `preceding-sexp` to `elisp--preceding-sexp`, and adds an alias to it for older versions of Emacs. (Since the rename is reasonably new)
